### PR TITLE
Changed get_aws_credentials function to pull creds from the destination first

### DIFF
--- a/s3direct/tests.py
+++ b/s3direct/tests.py
@@ -506,7 +506,7 @@ class AWSCredentialsTest(TestCase):
         )
         botocore_mock.get_session(
         ).get_credentials.return_value = credentials_mock
-        credentials = get_aws_credentials()
+        credentials = get_aws_credentials({})
         botocore_mock.get_session().get_credentials.assert_called_once_with()
         self.assertEqual(credentials.token, 'token')
         self.assertEqual(credentials.secret_key, 'secret_key')
@@ -515,7 +515,17 @@ class AWSCredentialsTest(TestCase):
     @override_settings(AWS_ACCESS_KEY_ID='local_access_key',
                        AWS_SECRET_ACCESS_KEY='local_secret_key')
     def test_retrieves_aws_credentials_from_django_config(self):
-        credentials = get_aws_credentials()
+        credentials = get_aws_credentials({})
         self.assertIsNone(credentials.token)
         self.assertEqual(credentials.secret_key, 'local_secret_key')
         self.assertEqual(credentials.access_key, 'local_access_key')
+
+    def test_retrieves_aws_credentials_from_destination_config(self):
+        dest = {
+            'aws_access_key': 'dest_access_key',
+            'aws_secret_key': 'dest_secret_key'
+        }
+        credentials = get_aws_credentials(dest)
+        self.assertIsNone(credentials.token)
+        self.assertEqual(credentials.secret_key, 'dest_secret_key')
+        self.assertEqual(credentials.access_key, 'dest_access_key')

--- a/s3direct/utils.py
+++ b/s3direct/utils.py
@@ -65,7 +65,15 @@ def get_key(key, user, file_name, dest, uuid_key):
     return object_key
 
 
-def get_aws_credentials():
+def get_aws_credentials(dest):
+    # Use access keys if given for the destination
+    access_key = dest.get('aws_access_key')
+    secret_key = dest.get('aws_secret_key')
+
+    if access_key and secret_key:
+        # AWS tokens are not created for pregenerated access keys
+        return AWSCredentials(None, secret_key, access_key)
+
     access_key = getattr(settings, 'AWS_ACCESS_KEY_ID', None)
     secret_key = getattr(settings, 'AWS_SECRET_ACCESS_KEY', None)
     if access_key and secret_key:

--- a/s3direct/views.py
+++ b/s3direct/views.py
@@ -76,7 +76,7 @@ def get_upload_params(request):
         resp = json.dumps({'error': 'S3 endpoint config missing.'})
         return HttpResponseServerError(resp, content_type='application/json')
 
-    aws_credentials = get_aws_credentials()
+    aws_credentials = get_aws_credentials(dest)
     if not aws_credentials.secret_key or not aws_credentials.access_key:
         resp = json.dumps({'error': 'AWS credentials config missing.'})
         return HttpResponseServerError(resp, content_type='application/json')
@@ -137,7 +137,7 @@ def generate_aws_v4_signature(request):
         resp = json.dumps({'error': 'S3 region config missing.'})
         return HttpResponseServerError(resp, content_type='application/json')
 
-    aws_credentials = get_aws_credentials()
+    aws_credentials = get_aws_credentials(dest)
     if not aws_credentials.secret_key or not aws_credentials.access_key:
         resp = json.dumps({'error': 'AWS credentials config missing.'})
         return HttpResponseServerError(resp, content_type='application/json')


### PR DESCRIPTION
what:
- Adds functionality to pull AWS credentials from the destination configuration as the first priority

why:
- Required functionality so that the django-s3direct library can be given AWS credentials other than those used by boto3

references:
- Asana Ticket: https://app.asana.com/0/1188034199927926/1200271933175434
